### PR TITLE
Github CI Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         lfs: true
         submodules: recursive
 
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |
@@ -68,10 +68,10 @@ jobs:
         lfs: true
         submodules: recursive
 
-    - name: Setup python 3.11
+    - name: Setup python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     # Note: Sionna dependencies crash with hermespy[documentation] due to outdated ipywidgets requirement on Sionna's side
     - name: Install doc dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         sudo apt update
         sudo apt-get install -y build-essential octave portaudio19-dev python-dev-is-python3 pandoc graphviz
         export MAKEFLAGS="-j $(grep -c ^processor /proc/cpuinfo)"
-        pip install -q -e .[test,documentation,quadriga,uhd,audio,scapy,sionna]
+        pip install -q -e .[develop,documentation,quadriga,uhd,audio,scapy,sionna]
 
     - name: Build documentation
       run: sphinx-build -v -j auto docssource/ documentation/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         sudo apt update
         sudo apt-get install -y build-essential octave portaudio19-dev python-dev-is-python3 pandoc graphviz
         export MAKEFLAGS="-j $(grep -c ^processor /proc/cpuinfo)"
-        pip install -q -e .[test,documentation,quadriga,uhd,audio,scapy,sionna]
+        pip install -q -e .[develop,documentation,quadriga,uhd,audio,scapy,sionna]
 
     - name: Build documentation
       run: sphinx-build -v -j auto docssource/ documentation/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
         lfs: true
         submodules: recursive
 
-    - name: Setup python 3.11
+    - name: Setup python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install doc dependencies
       run: |


### PR DESCRIPTION
Moved GitHub's CI configuration to Python 3.12 to prepare for the eventual phase-out of HermesPy's Python 3.11 support.