### PR TITLE
Fix multipath fading asymetric antenna numbers

### DIFF
--- a/hermespy/channel/fading/fading.py
+++ b/hermespy/channel/fading/fading.py
@@ -377,13 +377,11 @@ class MultipathFadingSample(ChannelSample):
             :self.num_receive_antennas, :self.num_transmit_antennas
         ]
 
-        # Propagate the transmitted samples
-        propagated_samples = np.zeros(
-            (_spatial_response.shape[0], num_propagated_samples), dtype=np.complex128
-        )
-
-        # Only if there is something to propagate in the first place
-        if propagated_samples.size > 0:
+        # Propagate the transmitted samples only if there is something to propagate in the first place
+        if num_propagated_samples > 0 and _spatial_response.shape[0] > 0:
+            propagated_samples = np.zeros(
+                (_spatial_response.shape[1], num_propagated_samples), dtype=np.complex128
+            )
             for path_impulse, path_num_delay_samples in self.__path_impulse_generator(
                 signal.num_samples
             ):
@@ -392,7 +390,11 @@ class MultipathFadingSample(ChannelSample):
                 ] += (signal * path_impulse[np.newaxis, :])
 
             # Apply the channel's spatial response
-            propagated_samples[::] = _spatial_response @ propagated_samples
+            propagated_samples = _spatial_response @ propagated_samples
+        else:
+            propagated_samples = np.zeros(
+                (_spatial_response.shape[0], num_propagated_samples), dtype=np.complex128
+            )
 
         # Return the result
         propagated_block = SignalBlock(


### PR DESCRIPTION
I was experimenting with different numbers of sending and receiving antennas and came across an error:

```
Traceback (most recent call last):
  File "/home/user/Desktop/minimal_example.py", line 29, in <module>
    drop = simulation.scenario.drop()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/hermespy/simulation/scenario.py", line 737, in drop
    return Scenario.drop(self)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/hermespy/core/scenario.py", line 847, in drop
    drop = self._drop()
           ^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/hermespy/simulation/scenario.py", line 762, in _drop
    channel_propagations, channel_realizations = self.propagate(device_transmissions, states)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/hermespy/simulation/scenario.py", line 601, in propagate
    propagation_matrix[device_alpha_idx, device_beta_idx] = beta_alpha_sample.propagate(
                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/hermespy/channel/channel.py", line 370, in propagate
    propagated_blocks = [self._propagate(b, interpolation_mode) for b in _signal.blocks]
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/venv/lib/python3.12/site-packages/hermespy/channel/fading/fading.py", line 390, in _propagate
    propagated_samples[
ValueError: operands could not be broadcast together with shapes (4,54016) (2,54016) (4,54016) 
```

which can be reproduced with this minimal test case (based on the [OFDM simplex-link example](https://hermespy.org/api/modem/waveforms.orthogonal.ofdm.html))

```python
from hermespy.channel import TDL, TDLType
from hermespy.modem import OFDMWaveform, PrefixType, SimplexLink, GridResource, GridElement, ElementType, SymbolSection
from hermespy.simulation import Simulation, SimulatedUniformArray, SimulatedIdealAntenna

carrier_frequency = 3.7e9
simulation = Simulation(seed=42)
tx_device = simulation.new_device(carrier_frequency=carrier_frequency, bandwidth=128e3,
                                  antennas=SimulatedUniformArray(SimulatedIdealAntenna, 1e-2, [2, 1, 1]))
rx_device = simulation.new_device(carrier_frequency=carrier_frequency, bandwidth=128e3,
                                  antennas=SimulatedUniformArray(SimulatedIdealAntenna, 1e-2, [4, 1, 1]))

channel = TDL(TDLType.C, 1e-7, doppler_frequency=10)
simulation.set_channel(tx_device, rx_device, channel)

grid_resources = [
    GridResource(16, PrefixType.CYCLIC, .1, [GridElement(ElementType.DATA, 7), GridElement(ElementType.REFERENCE, 1)]),
    GridResource(128, PrefixType.CYCLIC, .1, [GridElement(ElementType.DATA, 1)]),
]
grid_structure = [SymbolSection(64, [0, 1])]
waveform = OFDMWaveform(
    grid_resources=grid_resources,
    grid_structure=grid_structure,
    num_subcarriers=128,
)

link = SimplexLink(waveform=waveform)
link.connect(tx_device, rx_device)

drop = simulation.scenario.drop()
```

This appears to be caused by `propagated_samples` initially taking the shape of the receiving antenna, rather than the transmitting antenna, when propagating the signal. `propagated_samples` first needs to take the shape of `(signal * path_impulse[np.newaxis, :])`, before it is transformed to its final shape by `_spatial_response @ propagated_samples`.

This PR hopefully fixes this error, by preallocating `propagated_samples` to the shape of the transmitting antenna, and then re-allocating it with the application of the spatial response. (I couldn't figure out a way to re-use the preallocation due to the shape change.) In the event there is nothing to propagate, `propagated_samples` is allocated as before, i.e., directly matching the shape of the receiving antenna.