### PR TITLE
fix: correctly set antenna correlation

### DIFF
--- a/hermespy/channel/fading/fading.py
+++ b/hermespy/channel/fading/fading.py
@@ -924,7 +924,7 @@ class MultipathFadingChannel(
         if value is not None:
             value.channel = self
 
-        self.__alpha_correlation = value
+        self.__antenna_correlation = value
 
     @override
     def serialize(self, process: SerializationProcess) -> None:


### PR DESCRIPTION
I noticed that `fading.py` was setting the `__alpha_correlation` variable in the `@antenna_correlation.setter`.  `__alpha_correlation` is not used elsewhere in `fading.py` and looking at the history it looks like something that was missed out of 76cbae3.

This PR updates the anntena correction setting to correctly set the antenna correlation.